### PR TITLE
Implement a setting for caching device names

### DIFF
--- a/src/Flow.Launcher.Plugin.AudioDeviceSelector.Tests/AudioDevicesManagerTests.cs
+++ b/src/Flow.Launcher.Plugin.AudioDeviceSelector.Tests/AudioDevicesManagerTests.cs
@@ -1,5 +1,6 @@
 ﻿using Flow.Launcher.Plugin.AudioDeviceSelector.Audio;
 using System;
+using Flow.Launcher.Plugin.AudioDeviceSelector.Components;
 using Xunit;
 
 namespace Flow.Launcher.Plugin.AudioDeviceSelector.Tests
@@ -17,7 +18,7 @@ namespace Flow.Launcher.Plugin.AudioDeviceSelector.Tests
         [InlineData("Speakers(SRS-XB13 Stereo)", TitleTypeSettings.DeviceDescription, "SRS-XB13 Stereo")]
         public void Test_GetDeviceTitle(string friendlyName, TitleTypeSettings titleType, string expectedResult)
         {
-            var obj = new AudioDevicesManager();
+            var obj = new AudioDevicesManager(new Settings());
 
             var result = obj.GetDeviceTitle(friendlyName, titleType);
 

--- a/src/Flow.Launcher.Plugin.AudioDeviceSelector/Audio/AudioDevicesManager.cs
+++ b/src/Flow.Launcher.Plugin.AudioDeviceSelector/Audio/AudioDevicesManager.cs
@@ -2,19 +2,23 @@
 using NAudio.CoreAudioApi;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.ComponentModel;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
+using Flow.Launcher.Plugin.AudioDeviceSelector.Components;
+using NAudio.CoreAudioApi.Interfaces;
+using PropertyKeys = NAudio.CoreAudioApi.PropertyKeys;
 
 namespace Flow.Launcher.Plugin.AudioDeviceSelector.Audio
 {
-    public class AudioDevicesManager
+    public class AudioDevicesManager : IMMNotificationClient, IDisposable
     {
+        public Settings Settings { get; }
+        
         private List<MMDevice> devices = null;
         private DateTime lastDeviceUpdateTimeStamp = DateTime.Now;
         private int updateIntervalSeconds = 5;
         private MMDeviceEnumerator deviceEnumerator = new MMDeviceEnumerator();
+        private readonly Dictionary<string, string> idToNameMap = new();
 
         public List<MMDevice> Devices 
         { 
@@ -25,6 +29,37 @@ namespace Flow.Launcher.Plugin.AudioDeviceSelector.Audio
                 return devices; 
             } 
         }
+
+        public AudioDevicesManager(Settings settings) {
+            Settings = settings;
+            if (Settings.CacheDeviceNames) {
+                deviceEnumerator.RegisterEndpointNotificationCallback(this);
+            }
+
+            Settings.PropertyChanged += SettingsOnPropertyChanged;
+        }
+
+        private void SettingsOnPropertyChanged(object sender, PropertyChangedEventArgs e) {
+            if (e.PropertyName != nameof(Settings.CacheDeviceNames)) return;
+            if (Settings.CacheDeviceNames)
+                deviceEnumerator.RegisterEndpointNotificationCallback(this);
+            else {
+                deviceEnumerator.UnregisterEndpointNotificationCallback(this);
+                idToNameMap.Clear();
+            }
+        }
+
+        public string GetDeviceNameFromCache(MMDevice device) {
+            var id = device.ID;
+            if (idToNameMap.ContainsKey(id)) {
+                return idToNameMap[id];
+            }
+
+            var name = device.FriendlyName;
+            idToNameMap[id] = name;
+            return name;
+        }
+        
         public List<MMDevice> GetDevices()
         {
             var datetime1 = DateTime.Now;
@@ -33,6 +68,11 @@ namespace Flow.Launcher.Plugin.AudioDeviceSelector.Audio
             var endpoints = deviceEnumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
             foreach (var endpoint in endpoints)
             {
+                if (Settings.CacheDeviceNames) {
+                    // Puts the name in cache if it's not there yet
+                    GetDeviceNameFromCache(endpoint);
+                }
+
                 devices.Add(endpoint);
             }
 
@@ -97,6 +137,31 @@ namespace Flow.Launcher.Plugin.AudioDeviceSelector.Audio
             }
 
             return friendyName;
+        }
+
+        public void OnDeviceStateChanged(string deviceId, DeviceState newState) { }
+
+        public void OnDeviceAdded(string pwstrDeviceId) { }
+
+        public void OnDeviceRemoved(string deviceId) {
+            idToNameMap.Remove(deviceId);
+        }
+
+        public void OnDefaultDeviceChanged(DataFlow flow, Role role, string defaultDeviceId) { }
+
+        public void OnPropertyValueChanged(string pwstrDeviceId, PropertyKey key) {
+            if (!Settings.CacheDeviceNames) return;
+            if (key.propertyId != PropertyKeys.PKEY_Device_FriendlyName.propertyId &&
+                key.propertyId != PropertyKeys.PKEY_DeviceInterface_FriendlyName.propertyId)
+                return;
+            var device = deviceEnumerator.GetDevice(pwstrDeviceId);
+            idToNameMap[device.ID] = device.FriendlyName;
+        }
+
+        public void Dispose() {
+            Settings.PropertyChanged -= SettingsOnPropertyChanged;
+            if (!Settings.CacheDeviceNames) return;
+            deviceEnumerator.UnregisterEndpointNotificationCallback(this);
         }
     }
 }

--- a/src/Flow.Launcher.Plugin.AudioDeviceSelector/Components/Settings.cs
+++ b/src/Flow.Launcher.Plugin.AudioDeviceSelector/Components/Settings.cs
@@ -9,6 +9,7 @@ namespace Flow.Launcher.Plugin.AudioDeviceSelector.Components
         private bool displayFriendlyName;
         private bool displayDeviceName;
         private bool displayDeviceDescription;
+        private bool cacheDeviceNames;
 
         public Settings()
         {
@@ -42,6 +43,17 @@ namespace Flow.Launcher.Plugin.AudioDeviceSelector.Components
             set
             {
                 displayDeviceDescription = value;
+
+                OnPropertyChanged();
+            }
+        }
+
+        public bool CacheDeviceNames
+        {
+            get => cacheDeviceNames;
+            set
+            {
+                cacheDeviceNames = value;
 
                 OnPropertyChanged();
             }

--- a/src/Flow.Launcher.Plugin.AudioDeviceSelector/Languages/en.xaml
+++ b/src/Flow.Launcher.Plugin.AudioDeviceSelector/Languages/en.xaml
@@ -13,5 +13,8 @@
     <system:String x:Key="plugin_audiodeviceselector_settings_friendlynameoption">Friendly Name</system:String>
     <system:String x:Key="plugin_audiodeviceselector_settings_devicenameoption">Device Name</system:String>
     <system:String x:Key="plugin_audiodeviceselector_settings_devicedescriptionoption">Device Description</system:String>
+    
+    <system:String x:Key="plugin_audiodeviceselector_settings_cache_device_names_checkbox">Cache device names</system:String>
+    <system:String x:Key="plugin_audiodeviceselector_settings_cache_device_names_explanation">If checked, will make search much faster when you have many devices.</system:String>
 
 </ResourceDictionary>

--- a/src/Flow.Launcher.Plugin.AudioDeviceSelector/Main.cs
+++ b/src/Flow.Launcher.Plugin.AudioDeviceSelector/Main.cs
@@ -10,7 +10,7 @@ using Flow.Launcher.Plugin.AudioDeviceSelector.Views;
 namespace Flow.Launcher.Plugin.AudioDeviceSelector
 {
     [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class Main : IPlugin, IPluginI18n, ISettingProvider
+    public class Main : IPlugin, IPluginI18n, ISettingProvider, IDisposable
     {
         private PluginInitContext Context;
 
@@ -84,18 +84,19 @@ namespace Flow.Launcher.Plugin.AudioDeviceSelector
             {
                 string title = string.Empty;
                 string subTitle = string.Empty;
+                var friendlyName = settings.CacheDeviceNames ? audioDevicesManager.GetDeviceNameFromCache(device) : device.FriendlyName;
                 switch (titleType)
                 {
                     case TitleTypeSettings.FriendlyName:
-                        title = audioDevicesManager.GetDeviceTitle(device.FriendlyName, TitleTypeSettings.FriendlyName);
+                        title = audioDevicesManager.GetDeviceTitle(friendlyName, TitleTypeSettings.FriendlyName);
                         break;
                     case TitleTypeSettings.DeviceName:
-                        title = audioDevicesManager.GetDeviceTitle(device.FriendlyName, TitleTypeSettings.DeviceName);
-                        subTitle = audioDevicesManager.GetDeviceTitle(device.FriendlyName, TitleTypeSettings.DeviceDescription);
+                        title = audioDevicesManager.GetDeviceTitle(friendlyName, TitleTypeSettings.DeviceName);
+                        subTitle = audioDevicesManager.GetDeviceTitle(friendlyName, TitleTypeSettings.DeviceDescription);
                         break;
                     case TitleTypeSettings.DeviceDescription:
-                        title = audioDevicesManager.GetDeviceTitle(device.FriendlyName, TitleTypeSettings.DeviceDescription);
-                        subTitle = audioDevicesManager.GetDeviceTitle(device.FriendlyName, TitleTypeSettings.DeviceName);
+                        title = audioDevicesManager.GetDeviceTitle(friendlyName, TitleTypeSettings.DeviceDescription);
+                        subTitle = audioDevicesManager.GetDeviceTitle(friendlyName, TitleTypeSettings.DeviceName);
                         break;
                 }
 
@@ -112,7 +113,7 @@ namespace Flow.Launcher.Plugin.AudioDeviceSelector
                     {
                         try
                         {
-                            if (!audioDevicesManager.SetDevice(device.FriendlyName))
+                            if (!audioDevicesManager.SetDevice(friendlyName))
                             {
                                 // Show Notification Message if device is not found
                                 // Can happen in situations where since FlowLauncher was shown, the device went offline
@@ -159,7 +160,7 @@ namespace Flow.Launcher.Plugin.AudioDeviceSelector
             if (!settings.DisplayFriendlyName && !settings.DisplayDeviceName && !settings.DisplayDeviceDescription)
                 settings.DisplayFriendlyName = true;
 
-            audioDevicesManager = new AudioDevicesManager();
+            audioDevicesManager = new AudioDevicesManager(settings);
         }
 
         private string GetTranslatedDeviceNotFoundError(string deviceName)
@@ -186,6 +187,10 @@ namespace Flow.Launcher.Plugin.AudioDeviceSelector
         public string GetTranslatedPluginDescription()
         {
             return Context.API.GetTranslation("plugin_audiodeviceselector_plugin_description");
+        }
+
+        public void Dispose() {
+            audioDevicesManager.Dispose();
         }
     }
 }

--- a/src/Flow.Launcher.Plugin.AudioDeviceSelector/Views/SettingsUserControl.xaml
+++ b/src/Flow.Launcher.Plugin.AudioDeviceSelector/Views/SettingsUserControl.xaml
@@ -42,6 +42,10 @@
                     </StackPanel>
                 </StackPanel>
             </StackPanel>
+            <StackPanel Orientation="Vertical" Margin="0 0 8 0">
+                <CheckBox Name="CacheDeviceNamesCheckbox" Content="Cache device names" IsChecked="{Binding CacheDeviceNames}" />
+                <TextBlock Name="CacheDeviceNamesExplanation" TextWrapping="Wrap" MaxWidth="500" HorizontalAlignment="Left" Text="If checked, will make search much faster when you have many devices." />
+            </StackPanel>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/src/Flow.Launcher.Plugin.AudioDeviceSelector/Views/SettingsUserControl.xaml.cs
+++ b/src/Flow.Launcher.Plugin.AudioDeviceSelector/Views/SettingsUserControl.xaml.cs
@@ -64,6 +64,11 @@ namespace Flow.Launcher.Plugin.AudioDeviceSelector.Views
             FriendlyNameOption.Content = Context.API.GetTranslation("plugin_audiodeviceselector_settings_friendlynameoption");
             DeviceNameOption.Content = Context.API.GetTranslation("plugin_audiodeviceselector_settings_devicenameoption");
             DeviceDescriptionOption.Content = Context.API.GetTranslation("plugin_audiodeviceselector_settings_devicedescriptionoption");
+
+            CacheDeviceNamesCheckbox.Content =
+                Context.API.GetTranslation("plugin_audiodeviceselector_settings_cache_device_names_checkbox");
+            CacheDeviceNamesExplanation.Text =
+                Context.API.GetTranslation("plugin_audiodeviceselector_settings_cache_device_names_explanation");
         }
     }
 }


### PR DESCRIPTION
Fixes #15.

This PR implements an option in settings to cache device names. This should drastically improve performance for users with a lot of audio devices (5+).

Not only that, but even if the user decides not to use caching, it's still going to be about twice as fast for them if they're displaying both `DeviceName` and `DeviceDescription` in their search results. That's because I started putting `device.FriendlyName` to a local variable before getting the device name and description. Turned out that each call to `device.FriendlyName` takes about 30ms of time. By reducing the number of calls to that property in half, I also reduced the response delay in half.